### PR TITLE
Target either EF Core v2 or v3

### DIFF
--- a/CatFactory.EntityFrameworkCore/Definitions/Extensions/DbContextClassBuilder.cs
+++ b/CatFactory.EntityFrameworkCore/Definitions/Extensions/DbContextClassBuilder.cs
@@ -114,6 +114,7 @@ namespace CatFactory.EntityFrameworkCore.Definitions.Extensions
                     parameterType = "object";
                 }
 
+                var functionNamePropertyName = projectSelection.Settings.EfCoreTargetVersion == EfCoreVersion.EF2 ? "FunctionName" : "Name";
                 var method = new MethodDefinition
                 {
                     Attributes =
@@ -122,7 +123,7 @@ namespace CatFactory.EntityFrameworkCore.Definitions.Extensions
                         {
                             Sets =
                             {
-                                new MetadataAttributeSet("FunctionName", string.Format("\"{0}\"", scalarFunction.Name)),
+                                new MetadataAttributeSet(functionNamePropertyName, string.Format("\"{0}\"", scalarFunction.Name)),
                                 new MetadataAttributeSet("Schema", string.Format("\"{0}\"", scalarFunction.Schema))
                             }
                         }

--- a/CatFactory.EntityFrameworkCore/Definitions/Extensions/EntityConfigurationClassBuilder.cs
+++ b/CatFactory.EntityFrameworkCore/Definitions/Extensions/EntityConfigurationClassBuilder.cs
@@ -27,6 +27,8 @@ namespace CatFactory.EntityFrameworkCore.Definitions.Extensions
                 DbObject = table
             };
 
+            var projectSelection = project.GetSelection(table);
+
             definition.Namespaces.AddUnique(project.GetEntityLayerNamespace(project.Database.HasDefaultSchema(table) ? string.Empty : table.Schema));
 
             // todo: Check logic to build property's name
@@ -77,8 +79,9 @@ namespace CatFactory.EntityFrameworkCore.Definitions.Extensions
 
             if (table.Identity != null)
             {
+                var identityColumnMethod = projectSelection.Settings.EfCoreTargetVersion == EfCoreVersion.EF2 ? "UseSqlServerIdentityColumn" : "UseIdentityColumn";
                 configLines.Add(new CommentLine(" Set identity for entity (auto increment)"));
-                configLines.Add(new CodeLine("builder.Property(p => p.{0}).UseSqlServerIdentityColumn();", project.CodeNamingConvention.GetPropertyName(table.Identity.Name)));
+                configLines.Add(new CodeLine("builder.Property(p => p.{0}).{1}();", project.CodeNamingConvention.GetPropertyName(table.Identity.Name), identityColumnMethod));
                 configLines.Add(new EmptyLine());
             }
 
@@ -147,8 +150,6 @@ namespace CatFactory.EntityFrameworkCore.Definitions.Extensions
                     configLines.Add(new EmptyLine());
                 }
             }
-
-            var projectSelection = project.GetSelection(table);
 
             for (var i = 0; i < columns.Count; i++)
             {

--- a/CatFactory.EntityFrameworkCore/EntityFrameworkCoreProjectSettings.cs
+++ b/CatFactory.EntityFrameworkCore/EntityFrameworkCoreProjectSettings.cs
@@ -103,5 +103,16 @@ namespace CatFactory.EntityFrameworkCore
         /// When true use DefaultSchema (dbo) as namespace and class
         /// </summary>
         public bool DefaultSchemaAsNamespace { get; set; }
+
+        /// <summary>
+        /// Define EntityFrameworkCore version to target
+        /// </summary>
+        public EfCoreVersion EfCoreTargetVersion { get; set; }
+    }
+
+    public enum EfCoreVersion
+    {
+        EF2,
+        EF3,
     }
 }


### PR DESCRIPTION
Add a setting to target either version 2 or version 3 of Entity Framework Core

When targetting version 3, removes errors and warnings due to changes in EF Core

Solves #7 